### PR TITLE
MP3.sc: actually kill started processes

### DIFF
--- a/MP3.sc
+++ b/MP3.sc
@@ -130,7 +130,8 @@ MP3 {
 		if(pid.isNil, {
 			"MP3.stop - unable to stop automatically, PID not known".warn;
 		}, {
-			("kill" + pid).systemCmd;
+			// kill started shell and containing lame process
+			("kill" + pid.neg).systemCmd;
 			pid = nil;
 			playing = false;
 		});

--- a/MP3.sc
+++ b/MP3.sc
@@ -130,8 +130,8 @@ MP3 {
 		if(pid.isNil, {
 			"MP3.stop - unable to stop automatically, PID not known".warn;
 		}, {
-			// kill started shell and containing lame process
-			("kill" + pid.neg).systemCmd;
+			// kill started shell and containing decoder process
+			("kill --" + pid.neg).systemCmd;
 			pid = nil;
 			playing = false;
 		});

--- a/MP3.sc
+++ b/MP3.sc
@@ -131,7 +131,7 @@ MP3 {
 			"MP3.stop - unable to stop automatically, PID not known".warn;
 		}, {
 			// kill started shell and containing decoder process
-			("kill --" + pid.neg).systemCmd;
+			("pkill -P" + pid).systemCmd;
 			pid = nil;
 			playing = false;
 		});


### PR DESCRIPTION
- unixCmd doesn't return cmd PID but PID of shell containing command (see https://github.com/supercollider/supercollider/issues/1738)
- kill therefore in some cases didn't kill the cmd
- use pkill to kill whole group
