### PR TITLE
Couple of fixes for MP3 quark subprocesses

### DIFF
--- a/MP3.sc
+++ b/MP3.sc
@@ -152,7 +152,7 @@ MP3 {
 			if(pid.isNil, {
 				^true; // We can only assume it's still playing - we have no better info!
 			}, {
-				if(pid.isPIDRunning, {
+				if(pid.pidRunning, {
 					^true;
 				}, {
 					playing = false;

--- a/MP3.sc
+++ b/MP3.sc
@@ -128,9 +128,9 @@ MP3 {
 		pid = cmd.unixCmd({ |exit|
 			if(exit != 0) {
 				"MP3 subprocess (PID %) terminated with error code %".format(pid, exit).warn;
-				playing = false;
-				pid = nil;
 			};
+			playing = false;
+			pid = nil;
 		});
 		("MP3.start completed (PID"+(pid?"unknown")++")").postln;
 		playing = true;

--- a/MP3.sc
+++ b/MP3.sc
@@ -79,6 +79,10 @@ MP3 {
 
 		if(sampleRate.isNil){
 			sampleRate = Server.default.sampleRate;
+			if(sampleRate.isNil) {
+				"Sample rate not available, assuming 44100".warn;
+				sampleRate = 44100;
+			};
 		};
 		khz = sampleRate * 0.001;
 
@@ -121,7 +125,13 @@ MP3 {
 //			("MP3.start completed (PID"+(pid?"unknown")++")").postln;
 //			playing = true;
 //		});
-		pid = cmd.unixCmd;
+		pid = cmd.unixCmd({ |exit|
+			if(exit != 0) {
+				"MP3 subprocess (PID %) terminated with error code %".format(pid, exit).warn;
+				playing = false;
+				pid = nil;
+			};
+		});
 		("MP3.start completed (PID"+(pid?"unknown")++")").postln;
 		playing = true;
 	}

--- a/MP3.sc
+++ b/MP3.sc
@@ -137,7 +137,7 @@ MP3 {
 	}
 
 	stop {
-		if(pid.isNil, {
+		if(this.playing and: { pid.isNil }, {
 			"MP3.stop - unable to stop automatically, PID not known".warn;
 		}, {
 			("kill" + pid).systemCmd;


### PR DESCRIPTION
`pidRunning` has existed for 10 years.

`isPIDRunning` is gone -- "not understood."

Tested, works.